### PR TITLE
Add contact form via FormSpree

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,7 @@ author: 'EdinbR'
 author_image: "/assets/images/edinbr_300.png"
 
 gems: [jekyll-paginate]
+plugins: [jekyll-paginate]
 paginate: 5
 paginate_path: "page:num"
 

--- a/contact.md
+++ b/contact.md
@@ -1,0 +1,23 @@
+---
+layout: page
+title: Contact Us
+permalink: /contact/
+---
+
+If you need to get in touch with a member of the EdinbR organisation team, please use the form below to reach out to us
+
+<br/>
+
+<div class="row" style="display: flex;">
+  <form class="contact-form" action="https://formspree.io/f/xdopjdor" method="POST">
+    <label for="full-name">Name</label>
+    <input type="text" name="name" id="full-name" placeholder="First and Last" required>
+    <label for="email-address">Email Address</label>
+    <input type="email" name="_replyto" id="email-address" placeholder="Your email address" required>
+    <label for="message">Message</label>
+    <textarea rows="5" name="message" id="message" placeholder="Your message" required></textarea>
+    <input type="hidden" name="_subject" id="email-subject" value="Contact Form Submission">
+    <input type="submit" value="Submit">
+  </form>
+</div>
+

--- a/index.html
+++ b/index.html
@@ -41,6 +41,8 @@ layout: default
         &nbsp;&nbsp;·&nbsp;&nbsp;
         {% endfor %}
 	<a href="/code_of_conduct/">Code of conduct</a>
+        &nbsp;&nbsp;
+	<a href="/contact/">Contact Us</a>
 
     </div>
     <div id="home-search" class="home">


### PR DESCRIPTION
OK, so summary:

The contact page uses FormSpree for email delivery, which is free for <=50 submissions per month. It currently goes to me, but we can change that - it's registered under "edinbr@emeraldreverie.org" but we can add another address and reconfigure without having to redeploy the site. Likewise we can potentially change the login to FormSpree to a shared email too.

FormSpree has a ton of options which I have for now left at defaults. I will upload a screenshot so you can see what we have access to. The contact page renders a basic form and sends the POST to FormSpree, which then handles further actions. It is pluggable if we want to do fun things like collating responses in a spreadsheet etc.

The styling is *dreadful* because I suck at CSS. Improvements very much welcome.

The change to `_config.yml` is because newer versions of Jekyll seem to require "plugins" instead of "gems" - I'm not sure what version is being used to build the site so I added rather than replaced.